### PR TITLE
Fix array_merge error

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -90,7 +90,13 @@ class Oxygen_Repeater_Fix
 		}, $output );
 
 		$existing_ids = get_option( 'oxy_repeater_ids' );
-		$new_ids = array_merge( $existing_ids, Oxygen_Repeater_Fix_IDs::get_ids() );
+
+		if( $existing_ids != false ) {
+			$new_ids = array_merge( $existing_ids, Oxygen_Repeater_Fix_IDs::get_ids() );
+		}else{
+			$new_ids = Oxygen_Repeater_Fix_IDs::get_ids();
+		}
+		
 		if ( $existing_ids != $new_ids ) {
 			update_option( 'oxy_repeater_ids', $new_ids );
 		}


### PR DESCRIPTION
Fix error:array_merge(): Expected parameter 1 to be an array, bool given in
/home/public_html/mysite/wp-content/plugins/oxygen-repeater-fix-master/plugin.php
on line
93